### PR TITLE
Restrict email conflict check to this provider

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -51,7 +51,8 @@ class WikimediaAuthenticator < ::Auth::ManagedAuthenticator
     if !primary_email_verified?(auth_token) ||
        (existing_associated_account = ::UserAssociatedAccount.where(
         "info::json->>'email' = '#{raw_info['email']}' AND
-         provider_uid != '#{raw_info['sub']}'").exists?)
+         provider_uid != '#{raw_info['sub']}' AND
+         provider_name = 'mediawiki'").exists?)
       
       error_result = Auth::Result.new
       error_result.failed = true


### PR DESCRIPTION
When checking for conflicting accounts, only consider accounts
from this provider. discord-wikimedia-auth is not intended to be
used alongside other providers, but records might be left over
from a previous configuration.

Fixes #3.